### PR TITLE
修正从推荐页到其他页切换，Tab选中样式不跟随切换的问题

### DIFF
--- a/linjiashop-mobile/src/view/goods/goodsList.js
+++ b/linjiashop-mobile/src/view/goods/goodsList.js
@@ -67,7 +67,7 @@ export default {
     },
     methods: {
         init() {
-            this.activeNav = this.$route.query.itemId
+            this.activeNav = parseInt(this.$route.query.itemId)
             let categoryData = store.state.app.category
             if (!categoryData || categoryData.length == 0) {
                 let platform = navigator.platform


### PR DESCRIPTION
发现的问题：从推荐页（也就是首页）点击进入其他分类，Tab的选中样式（也就是底部的红线）不跟随切换

